### PR TITLE
Use merge=union in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@ frontend/parceltracker/parceltracker/Assets.xcassets/** linguist-generated=true
 frontend/parceltracker/parceltracker/Base.lproj/** linguist-generated=true
 frontend/parceltracker/parceltracker/Info.plist linguist-generated=true
 frontend/parceltracker/parceltracker/Preview Content/** linguist-generated=true
+
+*.pbxproj merge=union


### PR DESCRIPTION
tell git to merge using the union strategy, meaning it'll keep both sides during a merge. This is almost always what you want in the cse of a *.pbxproj merge conflict