### PR TITLE
'Your parcels' and tracking details linked & unified parcel and tracking data models

### DIFF
--- a/frontend/parceltracker/parceltracker/ContentView.swift
+++ b/frontend/parceltracker/parceltracker/ContentView.swift
@@ -36,6 +36,6 @@ struct ContentView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
-            .environment(\.colorScheme, .light)
+            .environment(\.colorScheme, .dark)
     }
 }

--- a/frontend/parceltracker/parceltracker/Models/Parcel.swift
+++ b/frontend/parceltracker/parceltracker/Models/Parcel.swift
@@ -11,8 +11,7 @@ import SwiftUI
 struct Parcel: Hashable, Codable, Identifiable {
     var id: Int
     var label: String
-    var trackingNumber: String
-    var courierId: Int
+    var trackingInfo: TrackingInfo
     var statusFilter: ParcelFilter
 }
 

--- a/frontend/parceltracker/parceltracker/Models/TrackingInfo.swift
+++ b/frontend/parceltracker/parceltracker/Models/TrackingInfo.swift
@@ -8,7 +8,7 @@
 struct TrackingInfo: Hashable, Codable, Identifiable {
     var id: Int
     var delivered: Bool
-    var courier: Courier
+    var courierId: Int
     var trackingNumber: String
-    var trackingInfo: [Status]
+    var statusUpdates: [Status]
 }

--- a/frontend/parceltracker/parceltracker/Resources/mockParcelData.json
+++ b/frontend/parceltracker/parceltracker/Resources/mockParcelData.json
@@ -1,80 +1,805 @@
 [
     {
         "label": "Books from ebay",
-        "trackingNumber": "3458340958",
-        "courierId": 1,
         "id": 0,
         "statusFilter": "Upcoming",
+        "trackingInfo": {
+            "id": 1,
+            "delivered": false,
+            "courierId": 1,
+            "trackingNumber": "AA123456789GB",
+            "statusUpdates": [
+                {
+                    "id": 1,
+                    "header": "Out For Delivery",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK"
+                },
+                {
+                    "id": 2,
+                    "header": "In Transit",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 3,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 4,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 5,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 6,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 7,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 8,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                }
+            ]
+        },
     },
     {
         "label": "Sweater",
-        "trackingNumber": "3458340958",
-        "courierId": 4,
         "id": 1,
         "statusFilter": "Past",
+        "trackingInfo": {
+            "id": 1,
+            "delivered": true,
+            "courierId": 4,
+            "trackingNumber": "AA123456789GB",
+            "statusUpdates": [
+                {
+                    "id": 1,
+                    "header": "Delivered",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Signature"
+                },
+                {
+                    "id": 2,
+                    "header": "Out For Delivery",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK"
+                },
+                {
+                    "id": 3,
+                    "header": "In Transit",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 4,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 5,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 6,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 7,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 8,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 9,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                }
+            ]
+        },
     },
     {
         "label": "New TV",
-        "trackingNumber": "3458340958",
-        "courierId": 3,
         "id": 2,
         "statusFilter": "Upcoming",
+        "trackingInfo": {
+            "id": 1,
+            "delivered": false,
+            "courierId": 3,
+            "trackingNumber": "AA123456789GB",
+            "statusUpdates": [
+                {
+                    "id": 1,
+                    "header": "Out For Delivery",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK"
+                },
+                {
+                    "id": 2,
+                    "header": "In Transit",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 3,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 4,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 5,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 6,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 7,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 8,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                }
+            ]
+        },
     },
     {
         "label": "Kettle for the new house",
-        "trackingNumber": "3458340958",
-        "courierId": 1,
         "id": 3,
         "statusFilter": "Past",
+        "trackingInfo": {
+            "id": 1,
+            "delivered": true,
+            "courierId": 1,
+            "trackingNumber": "AA123456789GB",
+            "statusUpdates": [
+                {
+                    "id": 1,
+                    "header": "Delivered",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Signature"
+                },
+                {
+                    "id": 2,
+                    "header": "Out For Delivery",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK"
+                },
+                {
+                    "id": 3,
+                    "header": "In Transit",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 4,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 5,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 6,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 7,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 8,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 9,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                }
+            ]
+        },
     },
     {
         "label": "Cat food",
-        "trackingNumber": "3458340958",
-        "courierId": 2,
         "id": 4,
         "statusFilter": "Past",
+        "trackingInfo": {
+            "id": 1,
+            "delivered": true,
+            "courierId": 2,
+            "trackingNumber": "AA123456789GB",
+            "statusUpdates": [
+                {
+                    "id": 1,
+                    "header": "Delivered",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Signature"
+                },
+                {
+                    "id": 2,
+                    "header": "Out For Delivery",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK"
+                },
+                {
+                    "id": 3,
+                    "header": "In Transit",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 4,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 5,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 6,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 7,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 8,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 9,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                }
+            ]
+        },
     },
     {
         "label": "Luigi's Mansion (Switch)",
-        "trackingNumber": "3458340958",
-        "courierId": 2,
         "id": 5,
         "statusFilter": "Upcoming",
+        "trackingInfo": {
+            "id": 1,
+            "delivered": false,
+            "courierId": 2,
+            "trackingNumber": "AA123456789GB",
+            "statusUpdates": [
+                {
+                    "id": 1,
+                    "header": "Out For Delivery",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK"
+                },
+                {
+                    "id": 2,
+                    "header": "In Transit",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 3,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 4,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 5,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 6,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 7,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 8,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                }
+            ]
+        },
     },
     {
         "label": "T2 Green Tea",
-        "trackingNumber": "3458340958",
-        "courierId": 0,
         "id": 6,
         "statusFilter": "Upcoming",
+        "trackingInfo": {
+            "id": 1,
+            "delivered": false,
+            "courierId": 0,
+            "trackingNumber": "AA123456789GB",
+            "statusUpdates": [
+                {
+                    "id": 1,
+                    "header": "Out For Delivery",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK"
+                },
+                {
+                    "id": 2,
+                    "header": "In Transit",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 3,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 4,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 5,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 6,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 7,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 8,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                }
+            ]
+        },
     },
     {
         "label": "New tshirt",
-        "trackingNumber": "3458340958",
-        "courierId": 1,
         "id": 7,
         "statusFilter": "Upcoming",
+        "trackingInfo": {
+            "id": 1,
+            "delivered": false,
+            "courierId": 1,
+            "trackingNumber": "AA123456789GB",
+            "statusUpdates": [
+                {
+                    "id": 1,
+                    "header": "Out For Delivery",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK"
+                },
+                {
+                    "id": 2,
+                    "header": "In Transit",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 3,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 4,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 5,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 6,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 7,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 8,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                }
+            ]
+        },
     },
     {
         "label": "Winter coat",
-        "trackingNumber": "3458340958",
-        "courierId": 2,
         "id": 8,
         "statusFilter": "Past",
+        "trackingInfo": {
+            "id": 1,
+            "delivered": true,
+            "courierId": 2,
+            "trackingNumber": "AA123456789GB",
+            "statusUpdates": [
+                {
+                    "id": 1,
+                    "header": "Delivered",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Signature"
+                },
+                {
+                    "id": 2,
+                    "header": "Out For Delivery",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK"
+                },
+                {
+                    "id": 3,
+                    "header": "In Transit",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 4,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 5,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 6,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 7,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 8,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 9,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                }
+            ]
+        },
     },
     {
         "label": "Wireless keyboard",
-        "trackingNumber": "3458340958",
-        "courierId": 2,
         "id": 9,
         "statusFilter": "Upcoming",
+        "trackingInfo": {
+            "id": 1,
+            "delivered": false,
+            "courierId": 2,
+            "trackingNumber": "AA123456789GB",
+            "statusUpdates": [
+                {
+                    "id": 1,
+                    "header": "Out For Delivery",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK"
+                },
+                {
+                    "id": 2,
+                    "header": "In Transit",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 3,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 4,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 5,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 6,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 7,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 8,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                }
+            ]
+        },
     },
     {
         "label": "Cactus plant",
-        "trackingNumber": "3458340958",
-        "courierId": 0,
         "id": 10,
         "statusFilter": "Upcoming",
+        "trackingInfo": {
+            "id": 1,
+            "delivered": false,
+            "courierId": 0,
+            "trackingNumber": "AA123456789GB",
+            "statusUpdates": [
+                {
+                    "id": 1,
+                    "header": "Out For Delivery",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK"
+                },
+                {
+                    "id": 2,
+                    "header": "In Transit",
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 3,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 4,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 5,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 6,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 7,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                },
+                {
+                    "id": 8,
+                    "date": "14.02.2019",
+                    "time": "15:35",
+                    "location": "Sheffield, UK",
+                    "statusType": "Warehouse Scan"
+                }
+            ]
+        },
     },
     
 ]

--- a/frontend/parceltracker/parceltracker/Views/Parcels/ParcelList.swift
+++ b/frontend/parceltracker/parceltracker/Views/Parcels/ParcelList.swift
@@ -52,7 +52,7 @@ struct ParcelList: View {
             // Parcel List
             List {
                 ForEach(parcelData.filter{($0.label.lowercased().hasPrefix(searchText.lowercased()) || searchText == "") && ($0.statusFilter == selectedParcelFilter.filter)}) { parcel in
-                    ParcelRow(parcelName: parcel.label, courierName: findCourierById(courierId: parcel.courierId)!.name)
+                    ParcelRow(parcel: parcel)
                 }
             }
         }

--- a/frontend/parceltracker/parceltracker/Views/Parcels/ParcelRow.swift
+++ b/frontend/parceltracker/parceltracker/Views/Parcels/ParcelRow.swift
@@ -11,17 +11,16 @@ var infoButtonSystemName = "info.circle"
 
 struct ParcelRow: View {
     @State var tag:Int? = nil
-    var parcelName: String
-    var courierName: String
+    var parcel: Parcel
     var body: some View {
         HStack {
             VStack {
                 HStack {
-                    Text(parcelName)
+                    Text(self.parcel.label)
                     Spacer()
                 }
                 HStack {
-                    Text(courierName)
+                    Text(courierData[self.parcel.trackingInfo.courierId].name)
                         .foregroundColor(.secondary)
                     Spacer()
                 }
@@ -33,7 +32,7 @@ struct ParcelRow: View {
                 
                 
                 ZStack {
-                    NavigationLink(destination: TrackParcel(tracking: trackingInfo, name: self.parcelName), tag: 1, selection: $tag){
+                    NavigationLink(destination: TrackParcel(parcel: self.parcel), tag: 1, selection: $tag){
                         EmptyView()
                     }.buttonStyle(PlainButtonStyle()).hidden().frame(width: 0)
                         
@@ -52,6 +51,6 @@ struct ParcelRow: View {
 
 struct ParcelRow_Previews: PreviewProvider {
     static var previews: some View {
-        ParcelRow(parcelName: "Books from ebay", courierName: "Royal Mail")
+        ParcelRow(parcel: parcelData[0])
     }
 }

--- a/frontend/parceltracker/parceltracker/Views/Parcels/ParcelRow.swift
+++ b/frontend/parceltracker/parceltracker/Views/Parcels/ParcelRow.swift
@@ -10,6 +10,7 @@ import SwiftUI
 var infoButtonSystemName = "info.circle"
 
 struct ParcelRow: View {
+    @State var tag:Int? = nil
     var parcelName: String
     var courierName: String
     var body: some View {
@@ -29,10 +30,20 @@ struct ParcelRow: View {
             HStack {
                 Text("Arriving Today") // TODO should merge the parcel status (parcelview PR) and parcel objects to get this info
                     .foregroundColor(.secondary)
-                Button(action: /*@START_MENU_TOKEN@*/{}/*@END_MENU_TOKEN@*/) {  // TODO add a link to the parcel view here
-                    Image(systemName: infoButtonSystemName)
+                
+                
+                ZStack {
+                    NavigationLink(destination: TrackParcel(tracking: trackingInfo, name: self.parcelName), tag: 1, selection: $tag){
+                        EmptyView()
+                    }.buttonStyle(PlainButtonStyle()).hidden().frame(width: 0)
+                        
+                    Button(action: {self.tag = 1}) {
+                        Image(systemName: infoButtonSystemName)
                         .imageScale(.large)
-                        .foregroundColor(.accentColor) // otherwise gets overwridden when inside a list
+                        .foregroundColor(.accentColor)  // otherwise gets overwridden when inside a list
+                    }
+                    
+                    
                 }
             }
         }

--- a/frontend/parceltracker/parceltracker/Views/Parcels/ParcelRow.swift
+++ b/frontend/parceltracker/parceltracker/Views/Parcels/ParcelRow.swift
@@ -30,7 +30,8 @@ struct ParcelRow: View {
                 Text("Arriving Today") // TODO should merge the parcel status (parcelview PR) and parcel objects to get this info
                     .foregroundColor(.secondary)
                 
-                
+                // A hack to get around the default navigationlink formatting inside a list (adds an arrow to the right)
+                // We create a Zstack with an invisible navigationlink to avoid auto formatting
                 ZStack {
                     NavigationLink(destination: TrackParcel(parcel: self.parcel), tag: 1, selection: $tag){
                         EmptyView()

--- a/frontend/parceltracker/parceltracker/Views/Parcels/TrackingInfo/ParcelStatusList.swift
+++ b/frontend/parceltracker/parceltracker/Views/Parcels/TrackingInfo/ParcelStatusList.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ParcelStatusList: View {
+    @Environment(\.colorScheme) var colorScheme: ColorScheme
     var delivered : Bool
     var updateList : [Status]
     
@@ -23,7 +24,7 @@ struct ParcelStatusList: View {
                         // But since it uses the width of the parent view, this is pretty robust for all devices.
                         .offset(x: symbolProxy.size.width/59.5)
                         .font(Font.system(size: IconSize, weight: .semibold))
-                        .foregroundColor(self.delivered ? .green : .black)
+                        .foregroundColor(self.delivered ? .green : (self.colorScheme == .light ? .black : .white))
                 }
                 
                 Spacer()
@@ -32,10 +33,16 @@ struct ParcelStatusList: View {
                     ParcelStatus(status: update)
                         .padding(.leading)
                         .border(width: TrackBarWidth, edge: .leading,
-                                color: (self.delivered ? .green : .black))
+                                color: (self.delivered ? .green : (self.colorScheme == .light ? .black : .white)))
                 }
             }
         }
         
+    }
+}
+
+struct ParcelStatusList_Previews: PreviewProvider {
+    static var previews: some View {
+        ParcelStatusList(delivered: false, updateList: parcelData[0].trackingInfo.statusUpdates)
     }
 }

--- a/frontend/parceltracker/parceltracker/Views/Parcels/TrackingInfo/TrackParcel.swift
+++ b/frontend/parceltracker/parceltracker/Views/Parcels/TrackingInfo/TrackParcel.swift
@@ -8,15 +8,13 @@
 import SwiftUI
 
 struct TrackParcel: View {
-    var parcelName : String
-    var trackingInfo : TrackingInfo
+    var parcel: Parcel
 
-    init(tracking : TrackingInfo, name : String) {
-        trackingInfo = tracking
-        parcelName = name
-        UITableView.appearance().separatorColor = .clear
-    }
-    
+//    init(parcel : Parcel) {
+//        self.parcel = parcel
+//        UITableView.appearance().separatorColor = .clear
+//    }
+//    
     var body: some View {
             // GeometryReader:
             // Used to get the width of the most outer view, from within a child view.
@@ -24,7 +22,7 @@ struct TrackParcel: View {
             GeometryReader { (stackProxy: GeometryProxy) in
                 
                 HStack {
-                    Text(self.trackingInfo.courier.name)
+                    Text(courierData[self.parcel.trackingInfo.courierId].name)
                         .fontWeight(.light)
                         .foregroundColor(.secondary)
                         // use width of device screen to space courier name below Nav title
@@ -32,24 +30,24 @@ struct TrackParcel: View {
                         .padding(.leading, stackProxy.size.width/100)
                         .padding(.top)
                     Spacer()
-                    Text(self.trackingInfo.trackingNumber)
+                    Text(self.parcel.trackingInfo.trackingNumber)
                         .fontWeight(.light)
                         .foregroundColor(.secondary)
                         .padding(.top)
                 }
                 .frame(height: -30) // negative height to space the subheading below the heading
                 
-                ParcelStatusList(delivered: self.trackingInfo.delivered, updateList: self.trackingInfo.trackingInfo)
+                ParcelStatusList(delivered: self.parcel.trackingInfo.delivered, updateList: self.parcel.trackingInfo.statusUpdates)
                     .padding(.top, 40) // padding at the top of the scroll view
                     .padding(.bottom, 40) // padding at the bottom of the scroll view
             }
             .padding()
-            .navigationBarTitle(parcelName)
+            .navigationBarTitle(self.parcel.label)
     }
 }
 
 struct TrackParcel_Previews: PreviewProvider {
     static var previews: some View {
-        TrackParcel(tracking: trackingInfo, name: "Books from Ebay")
+        TrackParcel(parcel: parcelData[0])
     }
 }

--- a/frontend/parceltracker/parceltracker/Views/Parcels/TrackingInfo/TrackParcel.swift
+++ b/frontend/parceltracker/parceltracker/Views/Parcels/TrackingInfo/TrackParcel.swift
@@ -18,7 +18,6 @@ struct TrackParcel: View {
     }
     
     var body: some View {
-        NavigationView {
             // GeometryReader:
             // Used to get the width of the most outer view, from within a child view.
             // This is used to generate the dynamic offset for the icon and sub headers.
@@ -45,9 +44,7 @@ struct TrackParcel: View {
                     .padding(.bottom, 40) // padding at the bottom of the scroll view
             }
             .padding()
-        
             .navigationBarTitle(parcelName)
-        }
     }
 }
 


### PR DESCRIPTION
## Description
- Linked parcel rows to their tracking views
- Unified and joined the parcel and tracking data objects (+ mock data)
- Improved the tracking view to show the tracking data of a selected parcel
- Added support for dark mode for the tracking view (the status like was black on a black background)


## Demo
[![Image from Gyazo](https://i.gyazo.com/02cd8de0925359ea3f208180e4abfd59.gif)](https://gyazo.com/02cd8de0925359ea3f208180e4abfd59)
